### PR TITLE
Fix API Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Initializes a new instance of the Validator class.
 
 <br>
 
-**`__call__(self, value, metadata={}) → ValidationResult`**
+**`validate(self, value, metadata={}) -> ValidationResult`**
 
 <ul>
 

--- a/validator/main.py
+++ b/validator/main.py
@@ -78,7 +78,7 @@ class FinancialTone(Validator):
             metadata.get("financial_tone_threshold", self.DEFAULT_THRESHOLD)
         )
 
-    def validate(self, value: str, metadata: Dict[str, Any]) -> ValidationResult:
+    def validate(self, value: str, metadata: Dict[str, Any] = {}) -> ValidationResult:
         """Validate that the generated text has a certain financial tone."""
         financial_tone, threshold = self._unpack_metadata(metadata)
         if not self.has_correct_financial_tone(value, financial_tone, threshold):


### PR DESCRIPTION
Previously the README for this validator contained the `→` character which is not supported in the standard character-set python uses internally for Windows. In general this should be `->` anyway because it should represent the typing syntax we use in python. See this issue for more details: https://github.com/guardrails-ai/guardrails/issues/648

This PR is part of a rolling set of updates to many validators.

This PR also adds a default value for metadata to match the API Reference in the README.